### PR TITLE
Switch to ImageIO

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,12 +1,12 @@
 name = "SixelTerm"
 uuid = "65edfddc-f399-4499-8369-a1bd38eee2ea"
-version = "1.1.1"
+version = "1.2.0"
 
 [deps]
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
-ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
+ImageIO = "82e4d734-157c-48bb-816b-45c225c6df19"
 
 [compat]
 FileIO = "1.4.1"
-ImageMagick = "1.2"
+ImageIO = "0.6.7"
 julia = "1.6"

--- a/README.md
+++ b/README.md
@@ -25,21 +25,18 @@ Here is an example using Plots with the default GR backend:
 
 ```julia
 ENV["GKSwstype"] = "nul"    # needed for the GR backend on headless servers
-using Plots
 using SixelTerm
+using Plots
 scatter(rand(100))
 ```
-Note that when using it with Plots, you have to do `using SixelTerm` after `using Plots`.
-For some reason, Plots.jl adds its own display to the stack, so we need the SixelTerm
-display added last.
 
 This is how things look in iTerm2:
 <img src="https://raw.githubusercontent.com/eschnett/SixelTerm.jl/master/demo.png" width=900px></img>
 
 Here is an example using Makie:
 ```julia
-using CairoMakie
 using SixelTerm
+using CairoMakie
 scatter(rand(100))
 ```
 
@@ -52,6 +49,4 @@ This package was written by [Tom Short](https://github.com/tshort) and
 is now maintained by [Erik Schnetter](https://github.com/eschnett).
 
 [TerminalGraphics](https://github.com/m-j-w/TerminalGraphics.jl) is another package that
-provides similar functionality. The main difference is that TerminalGraphics includes an
-interface to libsixel, while this package relies on ImageMagick for conversion to the Sixel
-format.
+provides similar functionality.

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -3,5 +3,5 @@ CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-CairoMakie = "0.8.13"
-julia = "1.5"
+CairoMakie = "0.10"
+julia = "1.6"


### PR DESCRIPTION
First of all, thank you for this package 🙂 

When setting up my new Mac, I ran into https://github.com/JuliaIO/ImageMagick.jl/issues/209. Based on how long this issue has been open, I assume it won't be fixed soon - but I would like to keep using SixelTerm! So in this PR I propose to replace ImageMagick.jl with ImageIO.jl and thereby remove the dependency on ImageMagick. Instead png, jpeg, sixel, ... support would be provided by ImageIO and the underlying libraries such as libsixel. With these changes I could use SixelTerm successfully on my Mac.

As a side effect (?) of this PR I noticed that the order of loading Plots and SixelTerm does not matter anymore - plotting in the terminal (iTerm2) worked in both cases.